### PR TITLE
implemented file upload

### DIFF
--- a/backend/controllers/tokenBookingController.js
+++ b/backend/controllers/tokenBookingController.js
@@ -195,8 +195,11 @@ exports.uploadPaymentProof = async (req, res, next) => {
       return next(new ErrorHandler('Not authorized to upload payment proof', 403));
     }
 
-    // Update payment proof
-    booking.paymentProof = req.file.path;
+    // Update payment proof with full URL path
+    const baseUrl = process.env.BASE_URL || 'http://localhost:8000';
+    const filePath = req.file.path.replace(/\\/g, '/'); // Convert Windows path to URL format
+    const relativePath = filePath.split('public')[1]; // Get path relative to public directory
+    booking.paymentProof = `${baseUrl}${relativePath}`;
     await booking.save();
 
     res.status(200).json({

--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -13,7 +13,8 @@ const createUploadDirs = () => {
     path.join(projectRoot, 'public'),
     path.join(projectRoot, 'public', 'uploads'),
     path.join(projectRoot, 'public', 'uploads', 'profile-images'),
-    path.join(projectRoot, 'public', 'uploads', 'images')
+    path.join(projectRoot, 'public', 'uploads', 'images'),
+    path.join(projectRoot, 'public', 'uploads', 'payment_proofs')
   ];
 
   dirs.forEach(dir => {
@@ -36,7 +37,8 @@ createUploadDirs();
 // Configure storage
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    cb(null, 'uploads/payment_proofs/');
+    const uploadPath = path.join(projectRoot, 'public', 'uploads', 'payment_proofs');
+    cb(null, uploadPath);
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Store payment proof files in a dedicated directory

- Save payment proof URLs as full URLs in database

- Ensure upload directories are created at startup


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tokenBookingController.js</strong><dd><code>Store payment proof as full URL in booking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/controllers/tokenBookingController.js

<li>Save payment proof as a full URL using BASE_URL.<br> <li> Normalize file path for cross-platform compatibility.<br> <li> Extract relative path from 'public' directory for URL construction.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S63_Palchhi_Capstone_Project_Rentora/pull/53/files#diff-87645c1bab2c57ad2859f60a4c0de448763d52725e4d6f1d4c8096c8ecd796ed">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upload.js</strong><dd><code>Add and use dedicated payment proofs upload directory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/middleware/upload.js

<li>Add 'payment_proofs' directory to upload structure.<br> <li> Ensure all upload directories are created at startup.<br> <li> Set multer storage destination to new payment proofs directory.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S63_Palchhi_Capstone_Project_Rentora/pull/53/files#diff-3ee665a3627cc63ad79aa80a75dbba856878ef65b5125b5958f01c4fa43cc32b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>