### PR TITLE
Matching design

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -23,7 +23,7 @@ const app = express();
 const server = http.createServer(app);
 const io = socketIo(server, {
   cors: {
-    origin: process.env.CLIENT_URL || "http://localhost:5173",
+    origin: [process.env.CLIENT_URL || "http://localhost:5173", "https://stellar-cobbler-864deb.netlify.app"],
     methods: ["GET", "POST"],
     credentials: true
   }
@@ -92,7 +92,8 @@ app.use(helmet({
 // CORS configuration
 const allowedOrigins = [
   process.env.FRONTEND_URL || 'http://localhost:5173',
-  'http://localhost:3000'
+  'http://localhost:3000',
+  'https://stellar-cobbler-864deb.netlify.app'
 ];
 
 app.use(cors({

--- a/frontend/client/src/api/axiosConfig.js
+++ b/frontend/client/src/api/axiosConfig.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+  baseURL: import.meta.env.VITE_API_URL || 'https://s63-palchhi-capstone-project-rentora-1.onrender.com/api',
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added Netlify frontend domain to CORS allowed origins.

- Updated API base URL in frontend Axios config.

- Enhanced backend CORS and socket.io configuration for deployment.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Add Netlify domain to backend CORS and socket.io origins</code>&nbsp; </dd></summary>
<hr>

backend/server.js

<li>Added 'https://stellar-cobbler-864deb.netlify.app' to allowed CORS <br>origins.<br> <li> Updated socket.io CORS origin to include Netlify domain.<br> <li> Improved CORS configuration for production frontend deployment.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S63_Palchhi_Capstone_Project_Rentora/pull/60/files#diff-e6a1d92480cd16cd30155f4e1694f991d54adcc2ad6611395c7798452f71af72">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>axiosConfig.js</strong><dd><code>Update Axios baseURL for production backend API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/client/src/api/axiosConfig.js

<li>Changed Axios baseURL to point to deployed backend API.<br> <li> Ensured frontend uses production backend endpoint.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S63_Palchhi_Capstone_Project_Rentora/pull/60/files#diff-4750dd66d61d32c13bb4b38f9c22922dc7861ff4898b8055fd708eb0f143b64e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>